### PR TITLE
Localstorage and badgetext

### DIFF
--- a/background/App.js
+++ b/background/App.js
@@ -332,8 +332,11 @@ var App = (function App(Output, Digger, Scraper, Logicker, Utils) {
             fileOptionzzz.push(fileOption);
         }
 
+        chrome.browserAction.setBadgeText({ text: '' + me.fileOptions.length + '' });
+        chrome.browserAction.setBadgeBackgroundColor({ color: [247, 81, 158, 255] });
+
         console.log('[App] Presented ' + me.fileOptions.length + ' file options.');
-        Output.toOut('Please select which files you would like to download.');
+        Output.toOut('Please select which of the ' + me.fileOptions.length + ' files you would like to download.');
         Output.showActionButtons();
 
         return Promise.resolve(fileOptionzzz);
@@ -598,7 +601,7 @@ var App = (function App(Output, Digger, Scraper, Logicker, Utils) {
                 if ((me.digOpts.doDig === false) && (me.digOpts.doScrape === false)) {
                     console.log('[App] Downloading ContentHelper uris');
                     
-                    chrome.storage.sync.set({
+                    chrome.storage.local.set({
                             prevUriMap: me.galleryMap
                         },
                         function() {
@@ -617,17 +620,6 @@ var App = (function App(Output, Digger, Scraper, Logicker, Utils) {
                 }
             })
             .then(me.presentFileOptions)
-            // .then(function(fileOpts) {
-            //     console.log('STARTING DOWNLOAD');
-
-            //     u.downloadInZip(fileOpts).then(function() {
-            //         for (var index = 0; index < fileOpts.length; index++) {
-            //             Output.setEntryAsDownloading(index);
-            //         };
-            //     });
-
-            //     return Promise.resolve([]); 
-            // })
             .catch(function handleError(errorMessage) {
                 console.log(errorMessage);
                 return Promise.reject(errorMessage);

--- a/background/Digger.js
+++ b/background/Digger.js
@@ -81,7 +81,7 @@ var Digger = (function Digger(Scraper, Output, Logicker, Utils, Options) {
      */
     function resolveDigHarvest() {
         return (new Promise(function(resolve, reject) {
-            chrome.storage.sync.set({
+            chrome.storage.local.set({
                     prevUriMap: me.harvestedUriMap,
                 },
                 function storageSet() {
@@ -524,7 +524,7 @@ var Digger = (function Digger(Scraper, Output, Logicker, Utils, Options) {
         //  yes scrape -- do it all normally through the default digDeep() behavior.
         if ((me.digOpts.doScrape === false) && (me.digOpts.doDig === false)) {
             return (new Promise(function(resolve, reject) {
-                chrome.storage.sync.set({
+                chrome.storage.local.set({
                         prevUriMap: me.harvestedUriMap,
                     },
                     function storageSet() {

--- a/background/Logicker.js
+++ b/background/Logicker.js
@@ -474,10 +474,16 @@ var Logicker = (function Logicker(Utils) {
      * Get a property value given a tag, and a dot-notation property path as a string.
      * It handles extracting from javascript functions, and from css properties.
      */
-    var URL_EXTRACTING_REGEX = /(url\()?('|")?(https?|data|blob|file)\:.+?\)?('|")?\)?/i;    
+    var URL_EXTRACTING_REGEX = /(url\()?('|")?(https?|data|blob|file)\:.+?\)?('|")?\)?/i;
+    var googleHackCounter = 0;    
     me.extractUrl = function extractUrl(tag, propPath, loc) {
         if (!tag || !propPath) {
             return '';
+        }
+
+        // horrible hack for google images.
+        if (tag.baseURI.indexOf('google.com') !== -1) {
+            return tag.parentNode.href;
         }
 
         // Iterate through the path of properties to get the value.

--- a/background/Scraper.js
+++ b/background/Scraper.js
@@ -488,9 +488,18 @@ var Scraper = (function Scraper(Utils, Logicker, Output) {
             {}
         );
 
-        console.log('[scraper] map: ' + u.toPrettyJson(harvestedUriMap));
-
-        return Promise.resolve(harvestedUriMap);
+        console.log('[Scraper] harvested map of length: ' + harvestedUris.length);
+        
+        return (new Promise(function(resolve, reject) {
+            chrome.storage.local.set({
+                    prevUriMap: harvestedUriMap,
+                },
+                function storageSet() {
+                    console.log('[Scraper] Set prevUriMap in storage');
+                    resolve(harvestedUriMap);
+                }
+            );
+        }));
     };
 
 

--- a/manifest.json
+++ b/manifest.json
@@ -3,7 +3,7 @@
 
   "name": "GimmeGimmeGimme",
   "description": "Shortcut to downloading. Named in honor of Black Flag's song, Gimme Gimme Gimme.",
-  "version": "0.1.2",
+  "version": "0.1.3",
   "offline_enabled": true,
 
   "icons": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "gimme",
-  "version": "0.1.2",
+  "version": "0.1.3",
   "description": "A tool for helping you download media from a page, or from the pages that are linked.",
   "main": "popup/popup.js",
   "dependencies": {

--- a/popup/popup.js
+++ b/popup/popup.js
@@ -13,7 +13,7 @@ document.addEventListener("DOMContentLoaded", function init() {
      * Note: clicking one of the "download all [ |jpgs]" button will clear them.
      */
     function setFileOptionList() {
-        chrome.storage.sync.get({
+        chrome.storage.local.get({
                 prevUriMap: {}
             }, 
             function storageRetrieved(store) {
@@ -51,6 +51,9 @@ document.addEventListener("DOMContentLoaded", function init() {
                         out.hideDigScrapeButtons();
                         out.showActionButtons();
                     }
+                    else {
+                        chrome.browserAction.setBadgeText({ text: '' });
+                    }
                 });
             }
         );
@@ -58,17 +61,19 @@ document.addEventListener("DOMContentLoaded", function init() {
 
 
     /**
-     * 
+     * Clear the persisted URI map from storage.
      */
     function clearPreviousUriMap() {
-        chrome.storage.sync.set({
+        chrome.browserAction.setBadgeText({ text: '' });
+        chrome.storage.local.set({
                 prevUriMap: {},
             },
             function storageSet() {
-                console.log('[Popup] Cleared prev uri map')
+                console.log('[Popup] Cleared prev uri map');
             }
         );    
     }
+
 
     /**
      * Connect up all the event handlers.

--- a/popup/style.css
+++ b/popup/style.css
@@ -4,9 +4,8 @@ body {
     font-family: monospace;
     font-size: 12px;
     min-height: 300px;
-    max-height: 700px;
+    max-height: 1024px;
     width: 700px;
-    overflow: auto;
 }
 
 h1 {


### PR DESCRIPTION
- Change uses of storage.sync to use storage.localStorage instead for persisting harvested URI maps
- Add badge that shows how many file download options are currently available.