### PR TITLE
V0.4.5

### DIFF
--- a/background/App.js
+++ b/background/App.js
@@ -502,7 +502,7 @@ var App = (function App(output, digger, scraper, Logicker, Utils) {
 
                 // make a simple chain of 
                 var id = 0;
-                
+                var galleryCount = 0;
                 Object.values(mapOfGalleryLinks).forEach(function(uri) { 
                     if (!!uri && !!uri.trim()) {                   
                         p = p.then(function() { 
@@ -510,6 +510,8 @@ var App = (function App(output, digger, scraper, Logicker, Utils) {
                             .then(function pushDoc(d) {
                                 console.log('[App] Executed load of gallery page ' + uri);
                                 output.toOut('Loading gallery page ' + uri);
+                                chrome.browserAction.setBadgeText({ text: '' + (++galleryCount) + '' });
+                                chrome.browserAction.setBadgeBackgroundColor({ color: '#4444ff' });
 
                                 locDocs.push({
                                     loc: new URL(uri),
@@ -520,6 +522,7 @@ var App = (function App(output, digger, scraper, Logicker, Utils) {
                                 console.log('[App] Failed to load gallery doc ' + uri)
                                 console.log('      Error: ' + e);
                                 output.toOut('Failed to load gallery page ' + uri);
+                                galleryCount--;
 
                                 return Promise.resolve(true);
                             });
@@ -530,7 +533,6 @@ var App = (function App(output, digger, scraper, Logicker, Utils) {
                 return p;
             })
             .then(function docsLoaded() {
-                var promises = [];
                 var p = Promise.resolve(true);
 
                 locDocs.forEach(function(lDoc) {

--- a/background/Digger.js
+++ b/background/Digger.js
@@ -277,7 +277,7 @@ var Digger = (function Digger(Scraper, Output, Logicker, Utils, Options) {
 
         // Create entries in the gallery map, the XHR tracking array, and the UI.
         if (u.exists(thumbUri) && u.exists(zoomUri)) {
-            if (!u.isBannedUri(zoomUri)) {
+            if (!u.isBannedZoomUri(zoomUri)) {
                 console.log(
                     '[Digger] Adding to map:\n' + 
                     '         thumbUri: ' + thumbUri + '\n' + 

--- a/background/Digger.js
+++ b/background/Digger.js
@@ -264,31 +264,6 @@ var Digger = (function Digger(Scraper, Output, Logicker, Utils, Options) {
         var nextId = fromKeys.length + Object.keys(to).length;
 
         to = Object.assign(to, from);
-
-        //me.redrawOutputFileOpts(me.galleryMap);
-
-        /*
-        // Apply the optionally-set me.urisToDig
-        fromKeys.forEach(function setNewLinkHrefs(thumbUri) {
-            // Store the old value, if there was one, and override with our new one.
-            var newPageUri = from[thumbUri];            
-            var oldPageUri = to[thumbUri];
-            var id = nextId;
-
-            if (!!oldPageUri) {
-                id = ids[oldPageUri];
-                Output.deleteEntry(id);
-                delete ids[oldPageUri];
-            }
-            else {
-                nextId++;
-            }
-            
-            to[thumbUri] = newPageUri;
-            ids[newPageUri] = id;
-            Output.addNewEntry(id, thumbUri);            
-        });
-        */        
     }
 
 
@@ -311,11 +286,7 @@ var Digger = (function Digger(Scraper, Output, Logicker, Utils, Options) {
 
                 // Create the associations, but do not add duplicates.
                 if (thumbUri in map) {
-                    // console.log(
-                    //     '[Digger] Found two zoomUris for thumb: ' + thumbUri + 
-                    //     '\n       keeping original: ' + map[thumbUri] + 
-                    //     '\n       discarding dupe:  ' + zoomUri
-                    // );
+                    return;
                 }
                 else {
                     var newId = Object.keys(map).length;
@@ -326,7 +297,6 @@ var Digger = (function Digger(Scraper, Output, Logicker, Utils, Options) {
             }
         }
     }
-
 
 
 
@@ -483,7 +453,6 @@ var Digger = (function Digger(Scraper, Output, Logicker, Utils, Options) {
         // This merges, and also manages the Output entries.
         if (!!me.startingGalleryMap && !!Object.keys(me.startingGalleryMap).length) {
             galleryMap = Object.assign({}, me.startingGalleryMap, galleryMap);
-            //mergeGalleryMaps(me.startingGalleryMap, galleryMap, me.outputIdMap);
         }
 
         // Begin digging, or stop if instructed to.
@@ -516,7 +485,9 @@ var Digger = (function Digger(Scraper, Output, Logicker, Utils, Options) {
             Output.setEntryAsDug(id, zoomedImgUri);
         } 
         
-        Output.toOut('Completed ' + (++me.completedXhrCount) + ' media fetches...');        
+        Output.toOut('Completed ' + (++me.completedXhrCount) + ' media fetches...');
+        chrome.browserAction.setBadgeText({ text: '' + me.completedXhrCount + '' });
+        chrome.browserAction.setBadgeBackgroundColor({ color: '#111111' });
     }
 
 
@@ -555,21 +526,6 @@ var Digger = (function Digger(Scraper, Output, Logicker, Utils, Options) {
         me.harvestedUriMap = {};
         me.outputIdMap = {};
 
-        // Follow the options. If we're told:
-        //  no scrape & no dig -- just call the callback. 
-        //  yes scrape -- do it all normally through the default digDeep() behavior.
-        // if ((me.digOpts.doScrape === false) && (me.digOpts.doDig === false)) {
-        //     return (new Promise(function(resolve, reject) {
-        //         chrome.storage.local.set({
-        //                 prevUriMap: me.startingGalleryMap,
-        //             },
-        //             function storageSet() {
-        //                 console.log('[Digger] Set prevUriMap in storage');
-        //                 resolve(me.startingGalleryMap);
-        //             }
-        //         );
-        //     }));
-        // }
         if (me.digOpts.doScrape) {
             return discoverGallery(doc, loc);
         }
@@ -898,9 +854,16 @@ var Digger = (function Digger(Scraper, Output, Logicker, Utils, Options) {
     // Return the Digger instance.
     return me;
 });
+
+// These are put on the Digger prototype so that the popup can easily set these values,
+// and they are available to all diggers.
 Digger.prototype.BATCH_SIZE = 3;
 Digger.prototype.CHANNELS = 11;
 
+
+/*
+ * Set the gallerygallerydig batch size from the options.
+ */
 Digger.prototype.setBatchSize = function setBatchSize(size) {
     console.log('[Digger] Attempt to set BATCH_SIZE to ' + size);
 
@@ -914,6 +877,10 @@ Digger.prototype.setBatchSize = function setBatchSize(size) {
     }
 };
 
+
+/*
+ * Set the gallerygallerydig number of channels from the options.
+ */
 Digger.prototype.setChannels = function setChannels(size) {
     console.log('[Digger] Attempt to set CHANNELS to ' + size);
 

--- a/background/EventPage.js
+++ b/background/EventPage.js
@@ -1,7 +1,7 @@
 'use strict'
 
 
-var outputController = undefined;
+var output = Output(document);
 
 //
 // Digging
@@ -21,8 +21,9 @@ function goDig(parentDocument) {
         js: true,
     };
 
-    var output = Output(parentDocument);
-    outputController = output;
+    output.setDoc(parentDocument);
+    output.resetFileData();
+    
     var scraper = Scraper(Utils, Logicker, output);
     var digger = Digger(scraper, output, Logicker, Utils, options);
     var app = App(output, digger, scraper, Logicker, Utils);
@@ -45,8 +46,9 @@ function goDigFileOptions(parentDocument) {
         js: true,
     };
 
-    var output = Output(parentDocument);
-    outputController = output;
+    output.setDoc(parentDocument);
+    output.resetFileData();
+    
     var scraper = Scraper(Utils, Logicker, output);
     var digger = Digger(scraper, output, Logicker, Utils, options);
     var app = App(output, digger, scraper, Logicker, Utils);
@@ -67,8 +69,9 @@ function goDigImageGallery(parentDocument) {
         js: true,
     };
 
-    var output = Output(parentDocument);
-    outputController = output;
+    output.setDoc(parentDocument);
+    output.resetFileData();
+    
     var scraper = Scraper(Utils, Logicker, output);
     var digger = Digger(scraper, output, Logicker, Utils, options);
     var app = App(output, digger, scraper, Logicker, Utils);
@@ -89,8 +92,9 @@ function goDigVideoGallery(parentDocument) {
         js: true,
     };
 
-    var output = Output(parentDocument);
-    outputController = output;
+    output.setDoc(parentDocument);
+    output.resetFileData();
+    
     var scraper = Scraper(Utils, Logicker, output);
     var digger = Digger(scraper, output, Logicker, Utils, options);
     var app = App(output, digger, scraper, Logicker, Utils);
@@ -110,8 +114,9 @@ function goDigGalleryGallery(parentDocument) {
         js: true,
     };
 
-    var output = Output(parentDocument);
-    outputController = output;
+    output.setDoc(parentDocument);
+    output.resetFileData();
+    
     var scraper = Scraper(Utils, Logicker, output);
     var digger = Digger(scraper, output, Logicker, Utils, options);
     var app = App(output, digger, scraper, Logicker, Utils);
@@ -142,8 +147,9 @@ function goScrape(parentDocument) {
         qs: true,
     };
 
-    var output = Output(parentDocument);
-    outputController = output;
+    output.setDoc(parentDocument);
+    output.resetFileData();
+    
     var scraper = Scraper(Utils, Logicker, output);
     var digger = Digger(scraper, output, Logicker, Utils, options);
     var app = App(output, digger, scraper, Logicker, Utils);
@@ -167,8 +173,9 @@ function goScrapeFileOptions(parentDocument) {
         qs: true,
     };
 
-    var output = Output(parentDocument);
-    outputController = output;
+    output.setDoc(parentDocument);
+    output.resetFileData();
+    
     var scraper = Scraper(Utils, Logicker, output);
     var digger = Digger(scraper, output, Logicker, Utils, options);
     var app = App(output, digger, scraper, Logicker, Utils);
@@ -191,8 +198,9 @@ function goScrapeImages(parentDocument) {
         qs: true,
     };
 
-    var output = Output(parentDocument);
-    outputController = output;
+    output.setDoc(parentDocument);
+    output.resetFileData();
+    
     var scraper = Scraper(Utils, Logicker, output);
     var digger = Digger(scraper, output, Logicker, Utils, options);
     var app = App(output, digger, scraper, Logicker, Utils);
@@ -215,8 +223,9 @@ function goScrapeVideos(parentDocument) {
         qs: true,
     };
 
-    var output = Output(parentDocument);
-    outputController = output;
+    output.setDoc(parentDocument);
+    output.resetFileData();
+    
     var scraper = Scraper(Utils, Logicker, output);
     var digger = Digger(scraper, output, Logicker, Utils, options);
     var app = App(output, digger, scraper, Logicker, Utils);

--- a/background/Logicker.js
+++ b/background/Logicker.js
@@ -12,6 +12,7 @@ var Logicker = (function Logicker(Utils) {
         MIN_ZOOM_HEIGHT: 250,
         MIN_ZOOM_WIDTH: 250,
 
+        knownBadImgRegex: /\/(logo\.|loading|header\.jpg|premium_|preview\.png|holder-trailer-home\.jpg|logo-mobile-w\.svg|logo\.svg|logo-desktop-w\.svg|user\.svg|speech\.svg|folder\.svg|layers\.svg|tag\.svg|video\.svg|favorites\.svg|spinner\.svg|preview\.jpg)/i,
         messages: [],
         processings: [],
         blessings: [],
@@ -31,10 +32,15 @@ var Logicker = (function Logicker(Utils) {
         me.blessings = JSON.parse(JSON.stringify(blessings));
     }
     me.setMinZoomHeight = function setMinZoomHeight(height) {
-        me.MIN_ZOOM_HEIGHT = height + 0;
+        me.MIN_ZOOM_HEIGHT = parseInt(height + '', 10);
     }
     me.setMinZoomWidth = function setMinZoomWidth(width) {
-        me.MIN_ZOOM_WIDTH = width + 0;
+        me.MIN_ZOOM_WIDTH = parseInt(width + '', 10);
+    }
+    me.setKnownBadImgRegex = function setKnownBadImgRegex(regexString) {
+        if (!!regex) {
+            me.knownBadImgRegex =  new RegExp(regexString);
+        }
     }
 
 
@@ -197,9 +203,10 @@ var Logicker = (function Logicker(Utils) {
     me.isKnownBadImg = function isKnownBadImg(src) {
         var isBad = false;
 
-        if ((/\/(logo\.|loading|header\.jpg|premium_|preview\.png|holder-trailer-home\.jpg|logo-mobile-w\.svg|logo\.svg|logo-desktop-w\.svg|user\.svg|speech\.svg|folder\.svg|layers\.svg|tag\.svg|video\.svg|favorites\.svg|spinner\.svg|preview\.jpg)/i).test(src))
-        {
-            isBad = true;
+        if (!!me.knownBadImgRegex) {
+            if (me.knownBadImgRegex.test(src)) {
+                isBad = true;
+            }
         }
 
         return isBad;

--- a/background/Logicker.js
+++ b/background/Logicker.js
@@ -32,13 +32,21 @@ var Logicker = (function Logicker(Utils) {
         me.blessings = JSON.parse(JSON.stringify(blessings));
     }
     me.setMinZoomHeight = function setMinZoomHeight(height) {
-        me.MIN_ZOOM_HEIGHT = parseInt(height + '', 10);
+        var zoomHeight = parseInt(height + '', 10);
+
+        if (!isNaN(zoomHeight)) {
+            me.MIN_ZOOM_HEIGHT = zoomHeight;
+        }
     }
     me.setMinZoomWidth = function setMinZoomWidth(width) {
-        me.MIN_ZOOM_WIDTH = parseInt(width + '', 10);
+        var zoomWidth = parseInt(width + '', 10);
+
+        if (!isNaN(zoomWidth)) {
+            me.MIN_ZOOM_WIDTH = zoomWidth;
+        }
     }
     me.setKnownBadImgRegex = function setKnownBadImgRegex(regexString) {
-        if (!!regex) {
+        if (!!regexString) {
             me.knownBadImgRegex =  new RegExp(regexString);
         }
     }

--- a/background/Logicker.js
+++ b/background/Logicker.js
@@ -12,7 +12,7 @@ var Logicker = (function Logicker(Utils) {
         MIN_ZOOM_HEIGHT: 250,
         MIN_ZOOM_WIDTH: 250,
 
-        knownBadImgRegex: /\/(logo\.|loading|header\.jpg|premium_|preview\.png|holder-trailer-home\.jpg|logo-mobile-w\.svg|logo\.svg|logo-desktop-w\.svg|user\.svg|speech\.svg|folder\.svg|layers\.svg|tag\.svg|video\.svg|favorites\.svg|spinner\.svg|preview\.jpg)/i,
+        knownBadImgRegex: '/\\/(logo\\.|loading|header\\.jpg|premium_|preview\\.png|holder-trailer-home\\.jpg|logo-mobile-w\\.svg|logo\\.svg|logo-desktop-w\\.svg|user\\.svg|speech\\.svg|folder\\.svg|layers\\.svg|tag\\.svg|video\\.svg|favorites\\.svg|spinner\\.svg|preview\\.jpg)/i',
         messages: [],
         processings: [],
         blessings: [],

--- a/background/Logicker.js
+++ b/background/Logicker.js
@@ -197,7 +197,7 @@ var Logicker = (function Logicker(Utils) {
     me.isKnownBadImg = function isKnownBadImg(src) {
         var isBad = false;
 
-        if ((/(\/logo\.|\/loading|\/header\.jpg|premium_|preview\.png|holder-trailer-home\.jpg|logo-mobile-w\.svg|logo\.svg|logo-desktop-w\.svg|user\.svg|speech\.svg|folder\.svg|layers\.svg|tag\.svg|video\.svg|favorites\.svg|spinner\.svg|preview\.jpg)/i).test(src))
+        if ((/\/(logo\.|loading|header\.jpg|premium_|preview\.png|holder-trailer-home\.jpg|logo-mobile-w\.svg|logo\.svg|logo-desktop-w\.svg|user\.svg|speech\.svg|folder\.svg|layers\.svg|tag\.svg|video\.svg|favorites\.svg|spinner\.svg|preview\.jpg)/i).test(src))
         {
             isBad = true;
         }

--- a/background/Logicker.js
+++ b/background/Logicker.js
@@ -12,7 +12,7 @@ var Logicker = (function Logicker(Utils) {
         MIN_ZOOM_HEIGHT: 250,
         MIN_ZOOM_WIDTH: 250,
 
-        knownBadImgRegex: '/\\/(logo\\.|loading|header\\.jpg|premium_|preview\\.png|holder-trailer-home\\.jpg|logo-mobile-w\\.svg|logo\\.svg|logo-desktop-w\\.svg|user\\.svg|speech\\.svg|folder\\.svg|layers\\.svg|tag\\.svg|video\\.svg|favorites\\.svg|spinner\\.svg|preview\\.jpg)/i',
+        knownBadImgRegex: /^SUPER_FAKE_NOT_FOUND_IN_NATURE_ONLY_ZOOL$/,
         messages: [],
         processings: [],
         blessings: [],

--- a/background/Output.js
+++ b/background/Output.js
@@ -70,6 +70,7 @@ var Output = (function Output(dokken) {
         me.fileOptMap = {};
         me.dugUris = [];
         me.failedUris = [];
+        me.checkedFileOptUris = [];
 
         var childNodes = undefined;
         try {
@@ -393,7 +394,7 @@ var Output = (function Output(dokken) {
     function restoreEntryStatus(entryObj) {
         return new Promise(function(resolve, reject) {
             setTimeout(function() {
-                console.log('[Output] restoring entry status.');
+                console.log('[Output] restoring entry status for: ' + entryObj.uri);
 
                 if (me.dugUris.indexOf(entryObj.id) !== -1) {
                     me.setEntryAsDug(entryObj.id, entryObj.uri);

--- a/background/Output.js
+++ b/background/Output.js
@@ -250,27 +250,20 @@ var Output = (function Output(dokken) {
 
         me.doc.getElementById(checkbox.id).addEventListener('click', function whenFileOptClicked(event) {
             var cb = event.currentTarget;
+            cb.checked = true;
+            cb.disabled = true;
 
             if (!!cb.dataset.filePath) {
-                cb.disabled = true;
-                cb.checked = true;
-
-                var ret = fileOpt.onSelect(cb.value, cb.dataset.filePath, me);
+                var p = fileOpt.onSelect(cb.value, cb.dataset.filePath+'', me);
                 
-                if (!!ret && !!ret.then) {
-                    ret.then(function(dlSig) {
-                        cb.dataset.filePath = '';
-                        cb.checked = true;
-                        cb.disabled = true;
+                if (!!p && !!p.then) {
+                    p.then(function() {
                         setFileOptUriChecked(cb.value);
                     });
                 }
-                else {
-                    cb.dataset.filePath = '';
-                    cb.checked = true;
-                    cb.disabled = true;
-                    setFileOptUriChecked(cb.value);
-                }
+            }
+            else {
+                setFileOptUriChecked(cb.value);
             }
         });
     };

--- a/background/Scraper.js
+++ b/background/Scraper.js
@@ -489,6 +489,8 @@ var Scraper = (function Scraper(Utils, Logicker, Output) {
         );
 
         console.log('[Scraper] harvested map of length: ' + harvestedUris.length);
+        chrome.browserAction.setBadgeText({ text: '' + harvestedUris.length + '' });
+        chrome.browserAction.setBadgeBackgroundColor({ color: '#9999FF' });
         
         return (new Promise(function(resolve, reject) {
             chrome.storage.local.set({
@@ -502,7 +504,7 @@ var Scraper = (function Scraper(Utils, Logicker, Output) {
         }));
     };
 
-
+    
     // return the singleton
     return me;
 })

--- a/background/Scraper.js
+++ b/background/Scraper.js
@@ -132,7 +132,7 @@ var Scraper = (function Scraper(Utils, Logicker, Output) {
                     }
 
                     // Only grab video srcs. turn the src into a uri, push it if it worked.
-                    if (vidSrc && vidSrc.match(/\.(mpg|mp4|mov|avi|wmv|flv)\.[\?](.+?)$/)) {
+                    if (vidSrc && vidSrc.match(/\.(mpg|mp4|mov|avi|wmv|flv)/i)) {
                         var cleansedUrl = u.srcToUrl(vidSrc, (loc || BLANK_LOC));
 
                         if (u.exists(cleansedUrl)) {

--- a/background/Utils.js
+++ b/background/Utils.js
@@ -105,14 +105,8 @@ var Utils = (function Utils() {
     /**
      * Does it match a regex in our list of blacklist regexes?
      */
-    me.isBannedUri = function isBannedUri(uri) {
+    me.isBannedZoomUri = function isBannedZoomUri(uri) {
         if (typeof uri === 'undefined') {
-            return true;
-        }
-        else if (/\/zip\.php\?/.test(uri)) {
-            return true;
-        }
-        else if (/\.zip/.test(uri)) {
             return true;
         }
         else {
@@ -126,7 +120,7 @@ var Utils = (function Utils() {
      */
     me.isKnownMediaType = function isKnownMediaType(name) {
         return (
-            !me.isBannedUri(name) &&
+            !me.isBannedZoomUri(name) &&
             (me.isAllowedImageType(name) || me.isAllowedVideoType(name) || me.isAllowedAudioType(name))  
         );
     };
@@ -361,10 +355,12 @@ var Utils = (function Utils() {
      * Add its downloading to one of the DL_CHAIN_COUNT download promise chains.
      */
     me.downloadFile = function downloadFile(uri, destFilename, output) {
-        if (uri.lastIndexOf('/') === uri.length - 1) { return; };
+        if (uri.lastIndexOf('/') === uri.length - 1) { 
+            return Promise.resolve(me.createDownloadSig(0, uri, destFilename)); 
+        };
 
-        // If it's a PHP file, guess and give it a .jpg.
-        if (!/\.(jpg|jpeg|png|gif|tiff|mpg|mp4|flv)$/i.test(destFilename)) {
+        // If it's not an expected file type, slap jpg on the end.
+        if (!/\.(jpg|jpeg|png|gif|tiff|mpg|mp4|flv|avi|zip|tar|gz|mp3|ogg|aac|m4a)$/i.test(destFilename)) {
             destFilename = destFilename + '.jpg';
         }
 

--- a/background/Utils.js
+++ b/background/Utils.js
@@ -387,6 +387,10 @@ var Utils = (function Utils() {
         return (
             function() {
                 output.toOut('Downloading file ' + num);
+
+                chrome.browserAction.setBadgeText({ text: '' + num + '' });
+                chrome.browserAction.setBadgeBackgroundColor({ color: '#009900' });
+
                 return me.dlInChain(uri, destFilename);
             }
         );

--- a/manifest.json
+++ b/manifest.json
@@ -3,7 +3,7 @@
 
   "name": "GimmeGimmeGimme",
   "description": "Shortcut to downloading. Named in honor of Black Flag's song, Gimme Gimme Gimme.",
-  "version": "0.4.2",
+  "version": "0.4.5",
   "offline_enabled": true,
 
   "applications": {

--- a/options/options.html
+++ b/options/options.html
@@ -5,7 +5,7 @@
         <link rel="stylesheet" href="options.css"/>
     </head>
     <body>
-        <h1>Enter your known specifications for websites and their galleries here.</h1>
+        <h1>options for tuning discovery of gallery digs</h1>
 
         <!-- config global values -->
         <div id="CONFIG">
@@ -15,21 +15,21 @@
 
         <!-- messages, per-site configurations -->
         <div id="MESSAGES">
-            <h3>per-site message descriptors</h3>
+            <h3>site-specific CSS selectors to match the gallery links, and to match the gallery thumbnails.</h3>
             <button id="addMessage" class="addEntry">add</button>
         </div>
 
 
         <!-- processings, per-site configurations -->
         <div id="PROCESSINGS">
-            <h3>per-site processings</h3>
+            <h3>site-specific uri transformations to get the full-sized img uri from the link uri or the thumbnail source uri uri.</h3>
             <button id="addProcessing" class="addEntry">add</button>
         </div>
 
 
         <!-- blessings, per-site configurations -->
         <div id="BLESSINGS">
-            <h3>per-site zoom-item URI blessings</h3>
+            <h3>site-specific css selectors to match the full-sized image on a detail page.</h3>
             <button id="addBlessing" class="addEntry">add</button>            
         </div>
 

--- a/options/options.html
+++ b/options/options.html
@@ -22,7 +22,7 @@
 
         <!-- processings, per-site configurations -->
         <div id="PROCESSINGS">
-            <h3>site-specific uri transformations to get the full-sized img uri from the link uri or the thumbnail source uri uri.</h3>
+            <h3>site-specific uri transformations to get the full-sized img uri from the link uri or the thumbnail source uri.</h3>
             <button id="addProcessing" class="addEntry">add</button>
         </div>
 

--- a/options/options.js
+++ b/options/options.js
@@ -18,33 +18,33 @@ var Constance = (function() {
     // Enumeration of the labels to use for the spec form elements.
     me.LABELS = {
         CONFIG: {
-            minZoomWidth: 'min zoom-item width',
-            minZoomHeight: 'min zoom-item height',
-            dlChannels: '# of download channels',
-            dlBatchSize: '# of downloads per batch',
-            knownBadImgRegex: 'file exclusion regex', 
+            minZoomWidth: 'min full-sized image width',
+            minZoomHeight: 'minimum full-sized image height',
+            dlChannels: 'number of download channels for gallery-gallery-digs',
+            dlBatchSize: 'number of downloads in a batch for gallery-gallery-digs',
+            knownBadImgRegex: 'regex to match image uris that are never what we are looking for', 
         },
         MESSAGES: {
-            match: 'uri-matcher',
-            link: 'link selector',
-            href: 'link uri property',
-            thumb: 'thumbnail sub-selector',
-            src: 'thumbnail uri property',
+            match: 'regex to match the site uri',
+            link: 'css selector for getting the link element pointing to the full-sized image page',
+            href: 'javascript property path for getting the proper link uri from the link element',
+            thumb: 'css scoped sub-selector of the thumbnail image element relative to the link element',
+            src: 'javascript property path for getting the proper thumbnail source uri from the thumbnail element',
         },
         PROCESSINGS: {
-            match: 'uri-matcher',
-            actions: 'action',
-            actions_noun: 'use property',
-            actions_verb: 'what to do',
-            actions_match: 'conditional matcher',
-            actions_new: 'new value',
-            dig: 'do digging?',
-            scrape: 'do scraping?',
+            match: 'regex to match the site uri',
+            actions: 'list of transformations to do on the matched uri',
+            actions_noun: 'do matching on the thumbnail image uri (src), or the link uri (href)',
+            actions_verb: 'the type of uri treansformation to do (ie "replace")',
+            actions_match: 'regex for what text in the selected src/href to replace/transform',
+            actions_new: 'new text for replacing/transforming the matched text of the uri',
+            dig: 'always use dig-engine discovery of full-sized images',
+            scrape: 'always use scrape-engine discovery of thumbnail images',
         },
         BLESSINGS: {
-            match: 'uri-matcher',
-            zoom: 'zoom-item selector',
-            src: 'zoom-item uri prop',
+            match: 'regex to match the site uri of detail pages containing the full-sized image',
+            zoom: 'css selector for the full-sized image element on the page',
+            src: 'javascript property path for getting the full-sized image source uri from the image element',
         },
     };
     
@@ -54,7 +54,7 @@ var Constance = (function() {
         minZoomHeight: '300',
         dlChannels: '5',
         dlBatchSize: '5',
-        knownBadImgRegex: '/\\/(logo\.|loading|header\\.jpg|premium_|preview\\.png|holder-trailer-home\\.jpg|logo-mobile-w\\.svg|logo\\.svg|logo-desktop-w\\.svg|user\\.svg|speech\\.svg|folder\\.svg|layers\\.svg|tag\\.svg|video\\.svg|favorites\\.svg|spinner\\.svg|preview\\.jpg)/i'
+        knownBadImgRegex: '/\\/(logo\\.|loading|header\\.jpg|premium_|preview\\.png|holder-trailer-home\\.jpg|logo-mobile-w\\.svg|logo\\.svg|logo-desktop-w\\.svg|user\\.svg|speech\\.svg|folder\\.svg|layers\\.svg|tag\\.svg|video\\.svg|favorites\\.svg|spinner\\.svg|preview\\.jpg)/i',
     };
     var cannedProcessings = [
         {

--- a/options/options.js
+++ b/options/options.js
@@ -22,7 +22,7 @@ var Constance = (function() {
             minZoomHeight: 'min zoom-item height',
             dlChannels: '# of download channels',
             dlBatchSize: '# of downloads per batch',
-            knownBadImgRegex: 'Regular expression that matches and blocks processing on known bad image-names.', 
+            knownBadImgRegex: 'file exclusion regex', 
         },
         MESSAGES: {
             match: 'uri-matcher',
@@ -54,7 +54,7 @@ var Constance = (function() {
         minZoomHeight: '300',
         dlChannels: '5',
         dlBatchSize: '5',
-        knownBadImgRegex: '/\/(logo\.|loading|header\.jpg|premium_|preview\.png|holder-trailer-home\.jpg|logo-mobile-w\.svg|logo\.svg|logo-desktop-w\.svg|user\.svg|speech\.svg|folder\.svg|layers\.svg|tag\.svg|video\.svg|favorites\.svg|spinner\.svg|preview\.jpg)/i'
+        knownBadImgRegex: '/\\/(logo\.|loading|header\\.jpg|premium_|preview\\.png|holder-trailer-home\\.jpg|logo-mobile-w\\.svg|logo\\.svg|logo-desktop-w\\.svg|user\\.svg|speech\\.svg|folder\\.svg|layers\\.svg|tag\\.svg|video\\.svg|favorites\\.svg|spinner\\.svg|preview\\.jpg)/i'
     };
     var cannedProcessings = [
         {

--- a/options/options.js
+++ b/options/options.js
@@ -38,8 +38,8 @@ var Constance = (function() {
             actions_verb: 'the type of uri treansformation to do (ie "replace")',
             actions_match: 'regex for what text in the selected src/href to replace/transform',
             actions_new: 'new text for replacing/transforming the matched text of the uri',
-            dig: 'always use dig-engine discovery of full-sized images',
-            scrape: 'always use scrape-engine discovery of thumbnail images',
+            dig: 'force always use dig-engine discovery of full-sized images',
+            scrape: 'force always use scrape-engine discovery of thumbnail images',
         },
         BLESSINGS: {
             match: 'regex to match the site uri of detail pages containing the full-sized image',

--- a/options/options.js
+++ b/options/options.js
@@ -21,7 +21,8 @@ var Constance = (function() {
             minZoomWidth: 'min zoom-item width',
             minZoomHeight: 'min zoom-item height',
             dlChannels: '# of download channels',
-            dlBatchSize: '# of downloads per batch', 
+            dlBatchSize: '# of downloads per batch',
+            knownBadImgRegex: 'Regular expression that matches and blocks processing on known bad image-names.', 
         },
         MESSAGES: {
             match: 'uri-matcher',
@@ -53,6 +54,7 @@ var Constance = (function() {
         minZoomHeight: '300',
         dlChannels: '5',
         dlBatchSize: '5',
+        knownBadImgRegex: '/\/(logo\.|loading|header\.jpg|premium_|preview\.png|holder-trailer-home\.jpg|logo-mobile-w\.svg|logo\.svg|logo-desktop-w\.svg|user\.svg|speech\.svg|folder\.svg|layers\.svg|tag\.svg|video\.svg|favorites\.svg|spinner\.svg|preview\.jpg)/i'
     };
     var cannedProcessings = [
         {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "gimme",
-  "version": "0.4.2",
+  "version": "0.4.5",
   "description": "A tool for helping you download media from a page, or from the pages that are linked.",
   "main": "popup/popup.js",
   "dependencies": {

--- a/popup/popup.html
+++ b/popup/popup.html
@@ -9,7 +9,7 @@
         <h1>gimme gimme gimme. need summore...</h1>
 
         <div id="buttonHolder">
-            <div class="doublewide">
+            <div id="mainButtonsHolder" class="doublewide" style="display:none">
                 <button id="digFileOptionsButton">dig file list</button>
                 <button id="scrapeFileOptionsButton">scrape file list</button>
                 <button id="toggleVoyeur">toggle voyeur</button>
@@ -17,13 +17,13 @@
                 
             </div>
 
-            <div class="buttonColumn">
+            <div id="scrapingButtonsHolder" class="buttonColumn">
                 <button id="scrapeImagesButton">scrape page images</button>
                 <button id="scrapeVideosButton">scrape page videos</button>
                 <button id="scrapeButton">scrape</button>
             </div>
 
-            <div class="buttonColumn">
+            <div id="diggingButtonsHolder" class="buttonColumn">
                 <button id="digImageGalleryButton">dig Image Gallery</button>
                 <button id="digVideoGalleryButton">dig Video Gallery</button>
                 <button id="digButton">dig</button>
@@ -31,7 +31,7 @@
         </div>
 
         <div id="outputHolder">
-            <span id="output">Hit a button to begin.</span>
+            <span id="output">...</span>
         </div>
         
         <div id="actionHolder" style="display: none;">

--- a/popup/popup.html
+++ b/popup/popup.html
@@ -10,11 +10,10 @@
 
         <div id="buttonHolder">
             <div id="mainButtonsHolder" class="doublewide" style="display:none">
-                <button id="digFileOptionsButton">dig file list</button>
-                <button id="scrapeFileOptionsButton">scrape file list</button>
-                <button id="toggleVoyeur">toggle voyeur</button>
+                <button id="scrapeFileOptionsButton">scrape page</button>
+                <button id="digFileOptionsButton">dig gallery</button>
                 <button id="digGalleryGallery">dig gallery gallery</button>                
-                
+                <button id="toggleVoyeur">toggle voyeur</button>
             </div>
 
             <div id="scrapingButtonsHolder" class="buttonColumn">

--- a/popup/popup.js
+++ b/popup/popup.js
@@ -19,7 +19,7 @@ document.addEventListener("DOMContentLoaded", function init() {
                 prevUriMap: {}
             }, 
             function storageRetrieved(store) {
-                var uriMap = store.prevUriMap;
+                var uriMap = store.prevUriMap
 
                 // If we're still in the digging/scraping stages, restore the textual file-list.
                 // If we're in the file option download stage, show the list of file option checkboxes instead.
@@ -35,8 +35,8 @@ document.addEventListener("DOMContentLoaded", function init() {
                         }
 
                         if (out.appIsScraping || out.appIsDigging) {
-                            chrome.browserAction.setBadgeText({ text: '' });
-                            out.toOut('Currently ' + (out.appIsScraping ? 'scraping' : 'digging') + '...');
+                            var descriptionOfWork = out.appIsScraping ? 'scraping...' : 'digging...';
+                            out.toOut('Currently ' + descriptionOfWork);
                             out.restoreFileList();
                             return;
                         }
@@ -51,6 +51,8 @@ document.addEventListener("DOMContentLoaded", function init() {
                             out = new bgWindow.Output(window.document);
                             out.checkedFileOptUris = cbUris;
                         }
+                        out.hideDigScrapeButtons();
+                        out.showActionButtons();
 
                         var dir = bgWindow.Utils.getSaltedDirectoryName();
                 
@@ -58,6 +60,10 @@ document.addEventListener("DOMContentLoaded", function init() {
                         bgWindow.Utils.resetDownloader();
 
                         var uriMapLength = Object.keys(uriMap).length;
+                        var alreadyCheckedItemsLength = (
+                            Array.isArray(document.checkedFileOptUris) ? document.checkedFileOptUris.length : 0
+                        );
+
                         var idx = uriMapLength - 1;
 
                         for (var thumbUri in uriMap) { 
@@ -90,11 +96,15 @@ document.addEventListener("DOMContentLoaded", function init() {
                             }
                         }
 
-                        out.hideDigScrapeButtons();
-                        out.toOut('Please select which of the ' + length + ' files you wish to download.');
-                        out.showActionButtons();
-                        chrome.browserAction.setBadgeText({ text: '' + (uriMapLength - idx) + '' });
+                        chrome.browserAction.setBadgeText({ text: '' + (uriMapLength - alreadyCheckedItemsLength) + '' });
                         chrome.browserAction.setBadgeBackgroundColor({ color: [247, 81, 158, 255] });
+
+                        if (!!cbUris && cbUris.length > 0) {
+                            out.toOut('Please select which of the ' + (uriMapLength - alreadyCheckedItemsLength) + ' remaining files you wish to download.');
+                        }
+                        else {
+                            out.toOut('Please select which of the total ' + uriMapLength + ' files you wish to download.');
+                        }
                     }
                     else {
                         chrome.browserAction.setBadgeText({ text: '' });
@@ -223,6 +233,7 @@ document.addEventListener("DOMContentLoaded", function init() {
                     bgWindow.outputController ? bgWindow.outputController : bgWindow.Output(window.document)
                 );                
                 out.clearFilesDug();
+                document.checkedFileOptUris = [];
                 out.showDigScrapeButtons();
                 out.toOut('Hit a button to begin.');
             });

--- a/popup/popup.js
+++ b/popup/popup.js
@@ -141,7 +141,7 @@ document.addEventListener("DOMContentLoaded", function init() {
                     minZoomHeight: '300',
                     dlChannels: '11',
                     dlBatchSize: '3',
-                    knownBadImgRegex: '/\\/(logo\.|loading|header\.jpg|premium_|preview\.png|holder-trailer-home\.jpg|logo-mobile-w\.svg|logo\.svg|logo-desktop-w\.svg|user\.svg|speech\.svg|folder\.svg|layers\.svg|tag\.svg|video\.svg|favorites\.svg|spinner\.svg|preview\.jpg)/i',
+                    knownBadImgRegex: '/\\/(logo\\.|loading|header\\.jpg|premium_|preview\\.png|holder-trailer-home\\.jpg|logo-mobile-w\\.svg|logo\\.svg|logo-desktop-w\\.svg|user\\.svg|speech\\.svg|folder\\.svg|layers\\.svg|tag\\.svg|video\\.svg|favorites\\.svg|spinner\\.svg|preview\\.jpg)/i',
                 },
                 messages: [],
                 processings: [],

--- a/popup/popup.js
+++ b/popup/popup.js
@@ -148,12 +148,6 @@ document.addEventListener("DOMContentLoaded", function init() {
                 bgWindow.Logicker.setMessages(store.spec.messages);
                 bgWindow.Logicker.setProcessings(store.spec.processings);
                 bgWindow.Logicker.setBlessings(store.spec.blessings);
-
-                console.log("Logicker:");
-                console.log(bgWindow.Logicker);
-
-                console.log("Digger:");
-                console.log(bgWindow.Digger);
             });
         });
     }

--- a/popup/popup.js
+++ b/popup/popup.js
@@ -141,6 +141,7 @@ document.addEventListener("DOMContentLoaded", function init() {
                     minZoomHeight: '300',
                     dlChannels: '11',
                     dlBatchSize: '3',
+                    knownBadImgRegex: '/\\/(logo\.|loading|header\.jpg|premium_|preview\.png|holder-trailer-home\.jpg|logo-mobile-w\.svg|logo\.svg|logo-desktop-w\.svg|user\.svg|speech\.svg|folder\.svg|layers\.svg|tag\.svg|video\.svg|favorites\.svg|spinner\.svg|preview\.jpg)/i',
                 },
                 messages: [],
                 processings: [],
@@ -154,6 +155,7 @@ document.addEventListener("DOMContentLoaded", function init() {
 
                 bgWindow.Logicker.setMinZoomHeight(store.spec.config.minZoomHeight);
                 bgWindow.Logicker.setMinZoomWidth(store.spec.config.minZoomWidth);
+                bgWindow.Logicker.setKnownBadImgRegex(store.spec.config.knownBadImgRegex);
 
                 bgWindow.Logicker.setMessages(store.spec.messages);
                 bgWindow.Logicker.setProcessings(store.spec.processings);

--- a/popup/style.css
+++ b/popup/style.css
@@ -5,6 +5,9 @@ body {
     font-size: 12px;
     min-height: 300px;
     max-height: 1024px;
+    height: 800px;
+    min-width: 600px;
+    max-width: 1024px;
     width: 700px;
 }
 


### PR DESCRIPTION
Vast improvements in keeping UI state throughout the whole dig/scrape/download process across multiple openings and closings of the UI popup. This includes downloading parts of a list, and having those file options still be marked as downloaded across openings/closings of the UI popup. The map of thumb -> zoom uris can now only be cleared by the user explicitly pressing the "clear file list" button. Badges have also been used to show counters during each part of the process. These simple color-coded counters give a much stronger sense of the app working, not just hanging in an unknown state until it finally presents its file options (as it was until this week).

Also the Options page has been changed to have much clearer verbiage describing the various configuration values. The "Known Bad Images" regex is also now exposed so the user can change it. 

Bug fixes and code cleanup all around as well, natch.