### PR TITLE
V0.4.9, build 2.

### DIFF
--- a/background/App.js
+++ b/background/App.js
@@ -9,8 +9,8 @@ import { default as Scraper } from './Scraper.js';
  * Factory function for the main "Application" backend of Gimme.
  */
 class App {
-    constructor(output, digger, scraper) {
-        this.output = output;
+    constructor(commonOutput, digger, scraper) {
+        this.output = commonOutput;
         this.digger = digger;
         this.scraper = scraper;
 
@@ -630,6 +630,6 @@ class App {
 
 }
 
-window.app = App;
+window['appClass'] = App;
 
 export default App;

--- a/background/Digger.js
+++ b/background/Digger.js
@@ -68,9 +68,9 @@ class Digger {
      * @param {Utils} Utils 
      * @param {InspecionOptions} someInspectionOptions 
      */
-    constructor(aScraper, anOutput, someInspectionOptions) {
+    constructor(aScraper, theOutput, someInspectionOptions) {
         this.scraper = aScraper;
-        this.output = anOutput;
+        this.output = theOutput;
 
         this.inspectionOptions = someInspectionOptions;
 
@@ -975,6 +975,6 @@ Digger.prototype.BATCH_SIZE = 3;
 Digger.prototype.CHANNELS = 11;
 
 
-window.digger = Digger;
+window['diggerClass'] = Digger;
 
 export default Digger;

--- a/background/EventPage.js
+++ b/background/EventPage.js
@@ -17,7 +17,7 @@ class EventPage {
      *  - CSS background-images
      *  - mucks through javascript (musta been green programmers)
      */
-    goDig(parentDocument) {
+    static goDig(parentDocument) {
         var inspectionOptions = {
             imgs: true,
             cssBgs: true,
@@ -25,12 +25,12 @@ class EventPage {
             js: true,
         };
 
-        output.setDoc(parentDocument);
-        output.resetFileData();
+        theOutput.setDoc(parentDocument);
+        theOutput.resetFileData();
         
-        var scraper = new Scraper(output);
-        var digger = new Digger(scraper, output, inspectionOptions);
-        var app = new App(output, digger, scraper);
+        var scraper = new Scraper(theOutput);
+        var digger = new Digger(scraper, theOutput, inspectionOptions);
+        var app = new App(theOutput, digger, scraper);
 
         app.digGallery();
     }
@@ -42,7 +42,7 @@ class EventPage {
      *  - CSS background-images
      *  - mucks through javascript (musta been green programmers)
      */
-     goDigFileOptions(parentDocument) {
+    static goDigFileOptions(parentDocument) {
         var inspectionOptions = {
             imgs: true,
             cssBgs: true,
@@ -50,12 +50,12 @@ class EventPage {
             js: true,
         };
 
-        output.setDoc(parentDocument);
-        output.resetFileData();
+        theOutput.setDoc(parentDocument);
+        theOutput.resetFileData();
         
-        var scraper = new Scraper(output);
-        var digger = new Digger(scraper, output, inspectionOptions);
-        var app = new App(output, digger, scraper);
+        var scraper = new Scraper(theOutput);
+        var digger = new Digger(scraper, theOutput, inspectionOptions);
+        var app = new App(theOutput, digger, scraper);
         
         app.digFileOptions();
     }
@@ -65,7 +65,7 @@ class EventPage {
      * Fire up the app, dig only for image galleries.
      * This includes css Background Images for bastards like FB.
      */
-     goDigImageGallery(parentDocument) {
+    static goDigImageGallery(parentDocument) {
         var inspectionOptions = {
             imgs: true,
             cssBgs: true,
@@ -73,12 +73,12 @@ class EventPage {
             js: true,
         };
 
-        output.setDoc(parentDocument);
-        output.resetFileData();
+        theOutput.setDoc(parentDocument);
+        theOutput.resetFileData();
         
-        var scraper = new Scraper(output);
-        var digger = new Digger(scraper, output, inspectionOptions);
-        var app = new App(output, digger, scraper);
+        var scraper = new Scraper(theOutput);
+        var digger = new Digger(scraper, theOutput, inspectionOptions);
+        var app = new App(theOutput, digger, scraper);
 
 
         app.digGallery();
@@ -88,7 +88,7 @@ class EventPage {
     /**
      * Fire up the app, dig only for video galleries.
      */
-     goDigVideoGallery(parentDocument) {
+    static goDigVideoGallery(parentDocument) {
         var inspectionOptions = {
             imgs: false,
             cssBgs: false,
@@ -96,12 +96,12 @@ class EventPage {
             js: true,
         };
 
-        output.setDoc(parentDocument);
-        output.resetFileData();
+        theOutput.setDoc(parentDocument);
+        theOutput.resetFileData();
         
-        var scraper = new Scraper(output);
-        var digger = new Digger(scraper, output, inspectionOptions);
-        var app = new App(output, digger, scraper);
+        var scraper = new Scraper(theOutput);
+        var digger = new Digger(scraper, theOutput, inspectionOptions);
+        var app = new App(theOutput, digger, scraper);
 
         app.digGallery();
     }
@@ -110,7 +110,7 @@ class EventPage {
     /**
      * Go dig multiple galleries from a page of gallery of galleries.
      */
-     goDigGalleryGallery(parentDocument) {
+    static goDigGalleryGallery(parentDocument) {
         var inspectionOptions = {
             imgs: true,
             cssBgs: true,
@@ -118,12 +118,12 @@ class EventPage {
             js: true,
         };
 
-        output.setDoc(parentDocument);
-        output.resetFileData();
+        theOutput.setDoc(parentDocument);
+        theOutput.resetFileData();
         
-        var scraper = new Scraper(output);
-        var digger = new Digger(scraper, output, inspectionOptions);
-        var app = new App(output, digger, scraper);
+        var scraper = new Scraper(theOutput);
+        var digger = new Digger(scraper, theOutput, inspectionOptions);
+        var app = new App(theOutput, digger, scraper);
 
         app.digGalleryGallery();
     }
@@ -141,7 +141,7 @@ class EventPage {
      * videos, audios, any urls inside of the <script> tags, and any urls in the 
      * query-string. Then JUST START DOWNLOADING THEM.
      */
-     goScrape(parentDocument) {
+    static goScrape(parentDocument) {
         var inspectionOptions = {
             imgs: true,
             cssBgs: true,
@@ -151,12 +151,12 @@ class EventPage {
             qs: true,
         };
 
-        output.setDoc(parentDocument);
-        output.resetFileData();
+        theOutput.setDoc(parentDocument);
+        theOutput.resetFileData();
         
-        var scraper = new Scraper(output);
-        var digger = new Digger(scraper, output, inspectionOptions);
-        var app = new App(output, digger, scraper);
+        var scraper = new Scraper(theOutput);
+        var digger = new Digger(scraper, theOutput, inspectionOptions);
+        var app = new App(theOutput, digger, scraper);
 
         app.scrape(inspectionOptions);
     }
@@ -167,7 +167,7 @@ class EventPage {
      * videos, any urls inside of the <script> tags, and any urls in the 
      * query-string. Then present options for the user to choose to download or not.
      */
-     goScrapeFileOptions(parentDocument) {
+    static goScrapeFileOptions(parentDocument) {
         var inspectionOptions = {
             imgs: true,
             cssBgs: true,
@@ -177,12 +177,12 @@ class EventPage {
             qs: true,
         };
 
-        output.setDoc(parentDocument);
-        output.resetFileData();
+        theOutput.setDoc(parentDocument);
+        theOutput.resetFileData();
         
-        var scraper = new Scraper(output);
-        var digger = new Digger(scraper, output, inspectionOptions);
-        var app = new App(output, digger, scraper);
+        var scraper = new Scraper(theOutput);
+        var digger = new Digger(scraper, theOutput, inspectionOptions);
+        var app = new App(theOutput, digger, scraper);
 
 
         app.scrapeFileOptions(inspectionOptions);
@@ -192,7 +192,7 @@ class EventPage {
     /**
      * Scrape the current page for <img>s.
      */
-     goScrapeImages(parentDocument) {
+    static goScrapeImages(parentDocument) {
         var inspectionOptions = {
             imgs: true,
             cssBgs: true,
@@ -202,12 +202,12 @@ class EventPage {
             qs: true,
         };
 
-        output.setDoc(parentDocument);
-        output.resetFileData();
+        theOutput.setDoc(parentDocument);
+        theOutput.resetFileData();
         
-        var scraper = new Scraper(output);
-        var digger = new Digger(scraper, output, inspectionOptions);
-        var app = new App(output, digger, scraper);
+        var scraper = new Scraper(theOutput);
+        var digger = new Digger(scraper, theOutput, inspectionOptions);
+        var app = new App(theOutput, digger, scraper);
 
 
         app.scrape(inspectionOptions);
@@ -217,7 +217,7 @@ class EventPage {
     /**
      * Scrape the current page for <video>s.
      */
-     goScrapeVideos(parentDocument) {
+    static goScrapeVideos(parentDocument) {
         var inspectionOptions = {
             imgs: false,
             cssBgs: false,
@@ -227,17 +227,17 @@ class EventPage {
             qs: true,
         };
 
-        output.setDoc(parentDocument);
-        output.resetFileData();
+        theOutput.setDoc(parentDocument);
+        theOutput.resetFileData();
         
-        var scraper = new Scraper(output);
-        var digger = new Digger(scraper, output, inspectionOptions);
-        var app = new App(output, digger, scraper);
+        var scraper = new Scraper(theOutput);
+        var digger = new Digger(scraper, theOutput, inspectionOptions);
+        var app = new App(theOutput, digger, scraper);
 
         app.scrape(inspectionOptions);
     }
 }
 
-window.eventPage = new EventPage();
+window['theEventPage'] = EventPage;
 
 export default EventPage;

--- a/background/Logicker.js
+++ b/background/Logicker.js
@@ -2,22 +2,11 @@ import * as tf from '../node_modules/@tensorflow/tfjs/dist/tf.esm';
 import * as mobilenet from '../node_modules/@tensorflow-models/mobilenet/dist/mobilenet.esm';
 import { default as Utils } from './Utils.js';
 
-const MOBILENET_MODEL_PATH = 'https://storage.googleapis.com/tfjs-models/tfjs/mobilenet_v1_0.25_224/model.json';
-const MOBILENET_TF_PATH = 'https://tfhub.dev/google/imagenet/mobilenet_v1_050_160/feature_vector/4';
+
+// Constants used by Logicker.
 const IMAGE_SIZE = 224;
 const CLASSIFICATIONS = 20;
 const PRED_CUTOFF = 0.2;
-const USE_TENSORFLOW = true;
-const MODEL_CONFIG = {
-    version: 2,
-    alpha: 0.25,
-    modelUrl: MOBILENET_MODEL_PATH,
-};
-const TF_MODEL_CONFIG = {
-    version: 2,
-    alpha: 0.25,
-    fromTFHub: true,
-};
 const URL_EXTRACTING_REGEX = /(url\()?('|")?(https?|data|blob|file)\:.+?\)?('|")?\)?/i;
 const MIN_ZOOM_HEIGHT = 250;
 const MIN_ZOOM_WIDTH = 250;
@@ -85,7 +74,6 @@ class Logicker {
                 console.log('[Logicker] Loading model...');
                 const startTime = performance.now();
 
-                //Logicker.mnModel = await tf.loadLayersModel(MOBILENET_MODEL_PATH, MODEL_CONFIG);
                 Logicker.mnModel = await mobilenet.load();
 
                 if (!!Logicker.mnModel) {
@@ -865,6 +853,6 @@ class Logicker {
     };
 }
 
-window.logicker = Logicker;
+window['theLogicker'] = Logicker;
 
 export default Logicker;

--- a/background/Output.js
+++ b/background/Output.js
@@ -36,8 +36,14 @@ class Output {
      */
     constructor(dokken) {
         this.doc = dokken;
-        this.filesDug = this.doc.getElementById(FILES_DUG_ID);
-        this.out = this.doc.getElementById(OUTPUT_ID);
+
+        try {
+            this.filesDug = this.doc.getElementById(FILES_DUG_ID);
+            this.out = this.doc.getElementById(OUTPUT_ID);
+        }
+        catch(err) {
+            console.log('[Output] Could not get elements from doc, it is a Dead Object.');
+        }
     }
 
 
@@ -63,10 +69,15 @@ class Output {
      */
     setDoc(dok) {
         this.doc = dok;
-        this.filesDug = this.doc.getElementById(FILES_DUG_ID);
-        this.out = this.doc.getElementById(OUTPUT_ID);
+        
+        try {
+            this.filesDug = this.doc.getElementById(FILES_DUG_ID);
+            this.out = this.doc.getElementById(OUTPUT_ID);
+        }
+        catch(err) {
+            console.log('[Output] Could not get elements from doc, it is a Dead Object.');
+        }
     }
-    
 
     /**
      * Enable the use of the half-baked features.
@@ -118,6 +129,7 @@ class Output {
         }
         catch(error) {
             console.log('[Output] Cannot set entry as downloading. doc reference is a Dead Object.');
+            return;
         }
         
         if (entry) { 
@@ -137,6 +149,7 @@ class Output {
         }
         catch(error) {
             console.log('[Output] Cannot change file entry state. doc ref is a Dead Object.');
+            return;
         }
         
         if (fEntry) {
@@ -215,6 +228,7 @@ class Output {
         }
         catch(error) {
             console.log('[Output] Could not delete entry. doc reference is a Dead Object.');
+            return;
         }
 
         if (fileLi) {
@@ -425,6 +439,6 @@ class Output {
     }
 }
 
-window.output = new Output(window.document);
+window['theOutput'] = new Output(window.document);
 
 export default Output;

--- a/background/Scraper.js
+++ b/background/Scraper.js
@@ -518,4 +518,6 @@ class Scraper {
     };
 }
 
+window['scraperClass'] = Scraper;
+
 export default Scraper;

--- a/background/Utils.js
+++ b/background/Utils.js
@@ -669,6 +669,6 @@ class Utils {
 }
 Utils.resetDownloader();
 
-window['Utils'] = Utils;
+window['theUtils'] = Utils;
 
 export default Utils;

--- a/background/Voyeur.js
+++ b/background/Voyeur.js
@@ -43,6 +43,6 @@ class Voyeur {
     };
 }
 
-window['Voyeur'] = Voyeur;
+window['theVoyeur'] = Voyeur;
 
 export default Voyeur;

--- a/content/ContentPeeper.js
+++ b/content/ContentPeeper.js
@@ -1,11 +1,8 @@
-const { uploadDenseMatrixToTexture } = require("@tensorflow/tfjs-core/dist/backends/webgl/gpgpu_util");
-
 // constants
 const GIMME_ID = 'gimme';
 const CONTENTPEEPER_ID = 'contentpeeper';
-const MAX_IMG_HEIGHT = 500;
-const MAX_IMG_WIDTH = 500;
-const URL_EXTRACTING_REGEX = /(url\()?(\'|\")?(https?:\/\/|data|blob)\:.+?(\'|\")?\)?/i;    
+const CONTENTPEEPER_WINDOW_KEY = 'GimmeGimmeGimme_ContentPeeper';
+
 
 /**
  * Client-Script for Gimme. Returns the location object, and will
@@ -302,6 +299,6 @@ class ContentPeeper {
     }
 }
 
-window['GimmeGimmeGimme_ContentPeeper'] = new ContentPeeper();
+window[CONTENTPEEPER_WINDOW_KEY] = new ContentPeeper();
 
 export default ContentPeeper;

--- a/manifest.json
+++ b/manifest.json
@@ -62,7 +62,8 @@
     "storage",
     "http://*/*",
     "https://*/*",
-    "file:///*/*"
+    "file:///*/*",
+    "chrome-extension://*/*"
   ],
 
   "web_accessible_resources": [

--- a/options/Optionator.js
+++ b/options/Optionator.js
@@ -480,7 +480,10 @@ class Optionator {
      */
     static getSpec() {
         var loadingDiv = document.getElementById('loading');
-        loadingDiv.style.display = 'block';
+
+        if (!!loadingDiv) {
+            loadingDiv.style.display = 'block';
+        }
 
         chrome.storage.sync.get({
                 spec: DEFAULT_SPEC
@@ -491,7 +494,9 @@ class Optionator {
                 Optionator.layoutProcessings(store.spec.processings);
                 Optionator.layoutBlessings(store.spec.blessings);
 
-                loadingDiv.style.display = 'none';
+                if (!!loadingDiv) {
+                    loadingDiv.style.display = 'none';
+                }
             }
         );
     }
@@ -676,6 +681,17 @@ class Optionator {
         return DEFAULT_SPEC.config;
     }
 }
-Optionator.setupOptionsPageOnLoad();
 
-export default Optionator;
+if (window.location.href.indexOf('options.html') === -1) {
+    console.log('[Optionator] some page other than Options called us. Return -- do nothing.');
+}
+else {
+    console.log('[Optionator] starting up, laying out the config form.');
+    Optionator.setupOptionsPageOnLoad();
+}
+
+window['theOptionator'] = Optionator;
+window['theDominatrix'] = Dominatrix;
+window['theConstance'] = Constance;
+
+export { Optionator as default, Dominatrix, Constance };

--- a/package.json
+++ b/package.json
@@ -2,8 +2,8 @@
   "name": "gimme",
   "version": "0.4.9",
   "description": "A tool for helping you download media from a page, or from the pages that are linked.",
-  "main": "popup/popup.js",
-  "module": "popup/popup.js",
+  "main": "popup/Popup.js",
+  "module": "popup/Popup.js",
   "dependencies": {
     "@babel/plugin-transform-runtime": "^7.10.1",
     "@babel/polyfill": "^7.10.1",
@@ -29,6 +29,7 @@
   },
   "scripts": {
     "pack": "webpack --config webpack.config.js",
+    "clean": "rm */bundle.js*",
     "test": "echo \"Error: no test specified\" && exit 1"
   },
   "repository": {

--- a/popup/Popup.js
+++ b/popup/Popup.js
@@ -31,7 +31,7 @@ class Popup {
                         // If we're in the file option download stage, show the list of file option checkboxes instead.
                         var length = Object.values(uriMap).length;
                         chrome.runtime.getBackgroundPage((bgWindow) => {
-                            var out = bgWindow.output;
+                            var out = bgWindow.theOutput;
                             out.setDoc(document);
 
                             if (out.appIsScraping || out.appIsDigging) {
@@ -50,10 +50,10 @@ class Popup {
 
                                 out.showActionButtons();
 
-                                var dir = bgWindow.Utils.getSaltedDirectoryName();
+                                var dir = bgWindow.theUtils.getSaltedDirectoryName();
                         
                                 out.clearFilesDug();
-                                bgWindow.Utils.resetDownloader();
+                                bgWindow.theUtils.resetDownloader();
 
                                 var checkedItemCount = 0;
                                 var idx = length - 1;
@@ -74,7 +74,7 @@ class Popup {
                                         uri: uri, 
                                         thumbUri: thumbUri,
                                         filePath: filePath,
-                                        onSelect: bgWindow.Utils.downloadFile, 
+                                        onSelect: bgWindow.theUtils.downloadFile, 
                                     });
 
                                     var cb = document.getElementById('cbFile' + optId);
@@ -138,18 +138,18 @@ class Popup {
                 }, 
                 function storageRetrieved(store) {
                     chrome.runtime.getBackgroundPage(function setSpec(bgWindow) {
-                        bgWindow.digger.setBatchSize(store.spec.config.dlBatchSize);
-                        bgWindow.digger.setChannels(store.spec.config.dlChannels);
+                        bgWindow.diggerClass.setBatchSize(store.spec.config.dlBatchSize);
+                        bgWindow.diggerClass.setChannels(store.spec.config.dlChannels);
 
-                        bgWindow.logicker.setMinZoomHeight(store.spec.config.minZoomHeight);
-                        bgWindow.logicker.setMinZoomWidth(store.spec.config.minZoomWidth);
-                        bgWindow.logicker.setKnownBadImgRegex(store.spec.config.knownBadImgRegex);
+                        bgWindow.theLogicker.setMinZoomHeight(store.spec.config.minZoomHeight);
+                        bgWindow.theLogicker.setMinZoomWidth(store.spec.config.minZoomWidth);
+                        bgWindow.theLogicker.setKnownBadImgRegex(store.spec.config.knownBadImgRegex);
 
-                        bgWindow.logicker.setMessages(store.spec.messages);
-                        bgWindow.logicker.setProcessings(store.spec.processings);
-                        bgWindow.logicker.setBlessings(store.spec.blessings);
+                        bgWindow.theLogicker.setMessages(store.spec.messages);
+                        bgWindow.theLogicker.setProcessings(store.spec.processings);
+                        bgWindow.theLogicker.setBlessings(store.spec.blessings);
 
-                        bgWindow.output.setEnableHalfBakedFeatures(
+                        bgWindow.theOutput.setEnableHalfBakedFeatures(
                             (store.spec.config.enableHalfBakedFeatures === ENABLE_HALF_BAKED_VAL)
                         );
                     });
@@ -174,7 +174,7 @@ class Popup {
                  */
                 document.getElementById('digFileOptionsButton').addEventListener('click', function onDigFileOptions() {
                     chrome.runtime.getBackgroundPage(function doDiggingForOptions(bgWindow) {
-                        bgWindow.eventPage.goDigFileOptions(window.document);
+                        bgWindow.theEventPage.goDigFileOptions(window.document);
                     });
                 });
 
@@ -185,7 +185,7 @@ class Popup {
                  */
                 document.getElementById('digGalleryGallery').addEventListener('click', function onDigGalleryGallery() {
                     chrome.runtime.getBackgroundPage(function doGalleryGalleryDigging(bgWindow) {
-                        bgWindow.eventPage.goDigGalleryGallery(window.document);
+                        bgWindow.theEventPage.goDigGalleryGallery(window.document);
                     });
                 });
 
@@ -224,7 +224,7 @@ class Popup {
                     chrome.runtime.getBackgroundPage(function clearTheFileList(bgWindow) {
                         clearPreviousUriMap();
                         
-                        var out = bgWindow.output;
+                        var out = bgWindow.theOutput;
                         out.setDoc(document);           
                         out.clearFilesDug();
                         out.resetFileData();
@@ -240,7 +240,7 @@ class Popup {
                  */
                 document.getElementById('scrapeFileOptionsButton').addEventListener('click', function onDigFileOptions() {
                     chrome.runtime.getBackgroundPage(function doScrapingForOptions(bgWindow) {
-                        bgWindow.eventPage.goScrapeFileOptions(window.document);
+                        bgWindow.theEventPage.goScrapeFileOptions(window.document);
                     });
                 });
 
@@ -250,7 +250,7 @@ class Popup {
                  */
                 document.getElementById("scrapeImagesButton").addEventListener("click", function onDigButton() {
                     chrome.runtime.getBackgroundPage(function doImageGalleryDig(bgWindow) {
-                        bgWindow.eventPage.goScrapeImages(window.document);
+                        bgWindow.theEventPage.goScrapeImages(window.document);
                     });
                 });
 
@@ -260,7 +260,7 @@ class Popup {
                  */
                 document.getElementById("scrapeVideosButton").addEventListener("click", function onDigButton() {
                     chrome.runtime.getBackgroundPage(function doImageGalleryDig(bgWindow) {
-                        bgWindow.eventPage.goScrapeVideos(window.document);
+                        bgWindow.theEventPage.goScrapeVideos(window.document);
                     });
                 });
 
@@ -270,7 +270,7 @@ class Popup {
                  */
                 document.getElementById("scrapeButton").addEventListener("click", function onDigButton() {
                     chrome.runtime.getBackgroundPage(function doImageGalleryDig(bgWindow) {
-                        bgWindow.eventPage.goScrape(window.document);
+                        bgWindow.theEventPage.goScrape(window.document);
                     });
                 });
 
@@ -280,7 +280,7 @@ class Popup {
                  */
                 document.getElementById("digImageGalleryButton").addEventListener("click", function onDigButton() {
                     chrome.runtime.getBackgroundPage(function doImageGalleryDig(bgWindow) {
-                        bgWindow.eventPage.goDigImageGallery(window.document);
+                        bgWindow.theEventPage.goDigImageGallery(window.document);
                     });
                 });
 
@@ -290,7 +290,7 @@ class Popup {
                  */
                 document.getElementById("digVideoGalleryButton").addEventListener("click", function onDigButton() {
                     chrome.runtime.getBackgroundPage(function doVideoGalleryDig(bgWindow) {
-                        bgWindow.eventPage.goDigVideoGallery(window.document);
+                        bgWindow.theEventPage.goDigVideoGallery(window.document);
                     });
                 });
 
@@ -300,7 +300,7 @@ class Popup {
                  */
                 document.getElementById("digButton").addEventListener("click", function onDigButton() {
                     chrome.runtime.getBackgroundPage(function doDigging(bgWindow) {
-                        bgWindow.eventPage.goDig(window.document);
+                        bgWindow.theEventPage.goDig(window.document);
                     });
                 });
 
@@ -310,11 +310,11 @@ class Popup {
                  */
                 document.getElementById("toggleVoyeur").addEventListener("click", function onToggleVoyeurButton() {
                     chrome.runtime.getBackgroundPage(function toggleVoyeur(bgWindow) {
-                        if (bgWindow.Voyeur.isWatching) {
-                            bgWindow.Voyeur.stop();
+                        if (bgWindow.theVoyeur.isWatching) {
+                            bgWindow.theVoyeur.stop();
                         }
                         else {
-                            bgWindow.Voyeur.start();
+                            bgWindow.theVoyeur.start();
                         }
                     });
                 });
@@ -323,6 +323,6 @@ class Popup {
     }
 }
 
-window.popup = new Popup();
+window['thePopup'] = new Popup();
 
 export default Popup;


### PR DESCRIPTION
- Do cleanup. 
- Remove unused constants
- change background-window keys of class objects and common instance object
- guard against Optionator running its setup on every time it's imported.